### PR TITLE
Fixed double auto/manual toggle

### DIFF
--- a/Examples/basic_drive_mode_control.cpp
+++ b/Examples/basic_drive_mode_control.cpp
@@ -38,12 +38,7 @@ void joystickCallback(const isc_shared_msgs::xinput::ConstPtr& joy){
 		updateDriveModeParameter();
 		ROS_INFO("Drive Mode Control: Switching to %s mode.", autoMode ? "AUTO" : "MANUAL");
 	}
-	if(startButtonDown && !joy->Start){ //The Start button has been released
-		startButtonDown = false;
-		autoMode = !autoMode;
-		updateDriveModeParameter();
-		ROS_INFO("Drive Mode Control: Switching to %s mode.", autoMode ? "AUTO" : "MANUAL");
-	}
+
 	speedBoostButton = joy->LS;//mike added this 6/3
 
 }


### PR DESCRIPTION
Second if statement at line 41 in joystickCallback would likely cause the state to never actually change regardless of button presses. Removing it should prevent the problem.