### PR TITLE
Bug fixes

### DIFF
--- a/Examples/basic_drive_mode_control.cpp
+++ b/Examples/basic_drive_mode_control.cpp
@@ -64,7 +64,7 @@ void manualCallback(const geometry_msgs::Twist::ConstPtr& msg){
 }
 
 void autoCallback(const geometry_msgs::Twist::ConstPtr& msg){
-	if(!autoMode){
+	if(autoMode){
 		float leftWheelSpeed = 0.0, rightWheelSpeed = 0.0;
 
 		leftWheelSpeed = (msg->linear.x - msg->angular.z);

--- a/isc_sick/launch/LMS1xx.launch
+++ b/isc_sick/launch/LMS1xx.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="host" default="192.168.0.100" />
-  <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
+  <node pkg="isc_sick" name="lms1xx" type="LMS1xx_node">
     <param name="host" value="$(arg host)" />
   </node>
 </launch>

--- a/isc_sick/src/LMS1xx_node.cpp
+++ b/isc_sick/src/LMS1xx_node.cpp
@@ -76,13 +76,13 @@ int main(int argc, char **argv)
     scan_msg.range_max = 20.0;
     scan_msg.scan_time = 100.0 / cfg.scaningFrequency;
     scan_msg.angle_increment = ((double)outputRange.angleResolution / 2) / 10000.0 * DEG2RAD;
-	if(tf_correction) {
-		scan_msg.angle_min = ((((double)cfg.startAngle) / 10000.0) - 90.0) * DEG2RAD;
+    if(tf_correction) {
+	scan_msg.angle_min = ((((double)cfg.startAngle) / 10000.0) - 90.0) * DEG2RAD;
     	scan_msg.angle_max = ((((double)cfg.stopAngle) / 10000.0) - 90.0) * DEG2RAD;
-	} else {
+    } else {
     	scan_msg.angle_min = ((double)cfg.startAngle ) / 10000.0 * DEG2RAD;
     	scan_msg.angle_max = ((double)cfg.stopAngle ) / 10000.0 * DEG2RAD;
-	}
+    }
 
     ROS_DEBUG_STREAM("Device resolution is " << (double)outputRange.angleResolution / 10000.0 << " degrees.");
     ROS_DEBUG_STREAM("Device frequency is " << (double)cfg.scaningFrequency / 100.0 << " Hz");


### PR DESCRIPTION
Basically, I have 3 changes.

1. Auto mode bug: A second if statement in the joystick callback would cause the drive_mode parameter to toggle from manual to auto, back to manual. As it only exists in the example code, it's not terribly important.

2. In the lms1xx launch file, the node pkg was left as lms1xx, when the enclosing package is actually isc_sick.

3. Our sick's reported range is from -45 to 225 degrees. ROS convention dictates that the 0 angle should be aligned with robot's forward facing axis (positive x, generally), but the sick's range would consider forward to be 90 degrees. I believe a similar problem was reported [here](https://github.com/amor-ros-pkg/rosaria/issues/53). Since it only matters for TF, I added it as a parameter that overrides current behavior, but keeps the current behavior as default.


